### PR TITLE
Easy to use api

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,36 +63,16 @@ Create a src/ directory inside your sketch, then clone or [download](https://git
 
 unzip **main.zip** and move the unziped folder named **uCtrl-main/** to **YourSketch/src/uCtrl/**
 
-### Setting your sketch
-
-Create a new file on IDE tab for your sketch named **modules.h**
-
-Configure **modules.h** accordly to the needed modules for your application.(see Modules for MACRO setup)
-
-### modules.h
-
-You should have a guard macro for this file:
-
-```c
-#ifndef __U_CTRL_MODULES_H__
-#define __U_CTRL_MODULES_H__
-
-// your uCtrl modules MACRO setup
-
-#endif
-```
-
 ### Initial Project structure 
 
 Your initial project structure should look like:  
 /YourSketch  
 /YourSketch/YourSketch.ino  
-/YourSketch/modules.h  
 /YourSketch/src/uCtrl/  
 
 # Modules
 
-A introduction to modules, base schematics and **modules.h** MACRO setup.
+A introduction to modules and base schematics setup.
 
 All the schematics are available as [PDF or Kicad format here](https://github.com/midilab/uMODULAR/tree/master/lib)
 
@@ -106,24 +86,6 @@ This module can handle single ADC ports on your microcontroller or multiplexed A
 
 [AIN 8 Potentiometers Schematic](https://github.com/midilab/uMODULAR/blob/master/lib/pot8.pdf)  
 [AIN 16 Potentiometers Schematic](https://github.com/midilab/uMODULAR/blob/master/lib/pot16.pdf)
-
-**modules.h**
-```c
-#ifndef __U_CTRL_MODULES_H__
-#define __U_CTRL_MODULES_H__
-
-// enables the driver
-#define USE_AIN
-
-// how many microncontrollers direct ADC pins you need?
-//#define USE_AIN_MAX_PORTS   8
-
-// for multiplexed support uncomment the needed driver
-#define USE_AIN_4051_DRIVER
-//#define USE_AIN_4067_DRIVER
-
-#endif
-```
 
 YourSketch.ino
 ```c++
@@ -219,44 +181,6 @@ This module can handle single Digital Input ports on your microcontroller or mul
 
 [DIN 8 Push Buttons Schematic](https://github.com/midilab/uMODULAR/blob/master/lib/push8.pdf)  
 [DIN 16 Push Buttons Schematic](https://github.com/midilab/uMODULAR/blob/master/lib/push16.pdf)
-
-**modules.h**
-```c
-#ifndef __U_CTRL_MODULES_H__
-#define __U_CTRL_MODULES_H__
-
-//
-// all pins are setup with internal pullup resistor
-// so wire you button between microcontroller pin and GND(no need for resistor)
-//
-
-// enables the driver
-#define USE_DIN
-
-// how many microncontrollers direct Input digital pins you need?
-//#define USE_DIN_MAX_PORTS   8
-
-// 2 driver options for multiplexed button input: SPI and BITBANG.
-// use only one driver option!
-
-//
-// using SPI hardware wich is the recommended way in case you have 
-// a Free or shared SPI device.
-//
-#define USE_DIN_SPI_DRIVER
-
-//
-// using bitbang in case you dont have a free SPI. 
-// this is slower and uses the CPU to process the data transfer.
-// this options requires you to define the latch, data and clock pins of 165.
-//
-//#define USE_DIN_BITBANG_DRIVER
-//#define DIN_LATCH_PIN   4
-//#define DIN_DATA_PIN    5
-//#define DIN_CLOCK_PIN   6
-
-#endif
-```
 
 YourSketch.ino
 ```c++
@@ -355,42 +279,6 @@ This module can handle single Digital output ports on your microcontroller or mu
 
 [DOUT 8 Leds Schematic](https://github.com/midilab/uMODULAR/blob/master/lib/led8.pdf)  
 [DOUT 16 Leds Schematic](https://github.com/midilab/uMODULAR/blob/master/lib/led16.pdf)
-
-**modules.h**
-```c
-#ifndef __U_CTRL_MODULES_H__
-#define __U_CTRL_MODULES_H__
-
-// enables the driver
-#define USE_DOUT
-
-//
-// for direct usage of microcontroller Digital output port pin
-// USE_DOUT_MAX_PORTS is default to 8 if you dont set it
-//
-//#define USE_DOUT_MAX_PORTS   8
-
-// 2 driver options for multiplexed output: SPI and BITBANG.
-// use only one driver option!
-
-//
-// using SPI hardware wich is the recommended way in case you have 
-// a Free or shared SPI device.
-//
-#define USE_DOUT_SPI_DRIVER
-
-//
-// using bitbang in case you dont have a free SPI. 
-// this is slower and uses the CPU to process the data transfer.
-// this options requires you to define the latch, data and clock pins of 595.
-//
-//#define USE_DOUT_BITBANG_DRIVER
-//#define DOUT_LATCH_PIN   7
-//#define DOUT_DATA_PIN    8
-//#define DOUT_CLOCK_PIN   9
-
-#endif
-```
 
 YourSketch.ino
 ```c++

--- a/module/ain/ain.cpp
+++ b/module/ain/ain.cpp
@@ -2,7 +2,7 @@
  *  @file       ain.cpp
  *  Project     Arduino Library API interface for uMODULAR projects
  *  @brief      Analog input driver module, supports uc analog ports and 4051/4067 multiplexers
- *  @version    1.0.0
+ *  @version    1.1.0
  *  @author     Romulo Silva
  *  @date       30/10/22
  *  @license    MIT - (c) 2022 - Romulo Silva - contact@midilab.co
@@ -25,11 +25,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE. 
  */
-
-#include "../../../../modules.h"
-
-#ifdef USE_AIN
-
 #include "ain.hpp"
 
 namespace uctrl { namespace module {
@@ -55,7 +50,6 @@ void Ain::setMaxAdcValue(uint16_t max_adc_value)
 	_user_adc_max_resolution = max_adc_value;
 }
 
-#if defined(USE_AIN_4051_DRIVER) || defined(USE_AIN_4067_DRIVER)
 void Ain::setMuxPins(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
 {
 	// setup pin 1
@@ -81,7 +75,6 @@ void Ain::setMuxPins(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
 #endif
 
 }
-#endif
 
 // call first all plug() for pin register, then plugMux()
 void Ain::plug(uint8_t setup)
@@ -98,7 +91,6 @@ void Ain::plug(uint8_t setup)
 	++_direct_pin_size;
 }
 
-#if defined(USE_AIN_4051_DRIVER) || defined(USE_AIN_4067_DRIVER)
 void Ain::plugMux(uint8_t setup)
 {
 	if (_host_analog_port >= USE_AIN_MAX_PORTS) 
@@ -110,8 +102,6 @@ void Ain::plugMux(uint8_t setup)
 	++_host_analog_port;
 	_remote_analog_port += AIN_MUX_SIZE;
 }
-#endif
-
 
 void Ain::init() 
 {
@@ -194,7 +184,6 @@ inline uint16_t Ain::rangeMe(uint16_t value, uint16_t min, uint16_t max)
 	return (value / (_adc_max_resolution / ((max - min) + 1))) + min;
 }
 
-#if defined(USE_AIN_4051_DRIVER) || defined(USE_AIN_4067_DRIVER)
 void Ain::selectMuxPort(uint8_t port)
 {
 	port = port%AIN_MUX_SIZE;
@@ -207,7 +196,6 @@ void Ain::selectMuxPort(uint8_t port)
 	digitalWrite(_mux_control_pin_4, bitRead(port, 3));	
 #endif
 }
-#endif
 
 void Ain::invertRead(bool state)
 {
@@ -323,4 +311,3 @@ int16_t Ain::getData(uint8_t remote_port, uint16_t min, uint16_t max)
 } }
 
 uctrl::module::Ain ain_module;
-#endif

--- a/module/ain/ain.hpp
+++ b/module/ain/ain.hpp
@@ -40,15 +40,13 @@ namespace uctrl { namespace module {
 #define USE_AIN_MAX_PORTS 8
 #endif
 
-#define USE_AIN_4051_DRIVER
+#define AIN_4051_MUX_SIZE	8
+#define AIN_4067_MUX_SIZE	16
 
-#if defined(USE_AIN_4051_DRIVER) 
-#define AIN_MUX_SIZE	8
-#endif
-
-#if defined(USE_AIN_4067_DRIVER)
-#define AIN_MUX_SIZE	16
-#endif
+typedef enum {
+	MUX_DRIVER_4051,
+	MUX_DRIVER_4067
+} MUX_DRIVERS;
 
 #ifdef ANALOG_AVG_READS
 typedef struct
@@ -93,12 +91,14 @@ class Ain
 		
 		void setMaxAdcValue(uint16_t max_adc_value);
 	
-		void setMuxPins(uint8_t pin1 = 0, uint8_t pin2 = 0, uint8_t pin3 = 0, uint8_t pin4 = 0);
+		void setMuxPins(int8_t pin1 = -1, int8_t pin2 = -1, int8_t pin3 = -1, int8_t pin4 = -1);
 		void selectMuxPort(uint8_t port);
 		int8_t _mux_control_pin_1 = -1;
 		int8_t _mux_control_pin_2 = -1;
 		int8_t _mux_control_pin_3 = -1;
 		int8_t _mux_control_pin_4 = -1;
+		int8_t _use_mux_driver = -1; // 0=4051, 1=4067
+		uint8_t _mux_size = 0;
 
 		int8_t _port[USE_AIN_MAX_PORTS] = {-1};
 

--- a/module/ain/ain.hpp
+++ b/module/ain/ain.hpp
@@ -1,8 +1,8 @@
 /*!
  *  @file       ain.hpp
  *  Project     Arduino Library API interface for uMODULAR projects
- *  @brief      Analog input driver module (4051 multiplexer)
- *  @version    1.0.0
+ *  @brief      Analog input driver module (4051/4067 multiplexer)
+ *  @version    1.1.0
  *  @author     Romulo Silva
  *  @date       30/10/22
  *  @license    MIT - (c) 2022 - Romulo Silva - contact@midilab.co
@@ -40,6 +40,8 @@ namespace uctrl { namespace module {
 #define USE_AIN_MAX_PORTS 8
 #endif
 
+#define USE_AIN_4051_DRIVER
+
 #if defined(USE_AIN_4051_DRIVER) 
 #define AIN_MUX_SIZE	8
 #endif
@@ -74,9 +76,7 @@ class Ain
 		void lockAllControls();
 		bool isLocked(uint8_t remote_port);
 		void plug(uint8_t setup);
-#if defined(USE_AIN_4051_DRIVER) || defined(USE_AIN_4067_DRIVER)
 		void plugMux(uint8_t setup);
-#endif		
 		void invertRead(bool state);		
 		uint8_t sizeOf();
 
@@ -93,13 +93,12 @@ class Ain
 		
 		void setMaxAdcValue(uint16_t max_adc_value);
 	
-#if defined(USE_AIN_4051_DRIVER)
 		void setMuxPins(uint8_t pin1 = 0, uint8_t pin2 = 0, uint8_t pin3 = 0, uint8_t pin4 = 0);
 		void selectMuxPort(uint8_t port);
 		int8_t _mux_control_pin_1 = -1;
 		int8_t _mux_control_pin_2 = -1;
 		int8_t _mux_control_pin_3 = -1;
-#endif
+		int8_t _mux_control_pin_4 = -1;
 
 		int8_t _port[USE_AIN_MAX_PORTS] = {-1};
 

--- a/module/device/device.cpp
+++ b/module/device/device.cpp
@@ -1,5 +1,3 @@
-#include "../../../../modules.h"
-
 #ifdef USE_DEVICE
 
 #include "../../uCtrl.h"

--- a/module/din/din.hpp
+++ b/module/din/din.hpp
@@ -2,7 +2,7 @@
  *  @file       din.hpp
  *  Project     Arduino Library API interface for uMODULAR projects
  *  @brief      Digital input driver module (165 shiftregister)
- *  @version    1.0.0
+ *  @version    1.1.0
  *  @author     Romulo Silva
  *  @date       30/10/22
  *  @license    MIT - (c) 2022 - Romulo Silva - contact@midilab.co
@@ -36,10 +36,6 @@ namespace uctrl { namespace module {
 
 #define DIN_EVENT_QUEUE_SIZE	4
 
-#if !defined(USE_DIN_MAX_PORTS)
-#define USE_DIN_MAX_PORTS 16
-#endif
-
 typedef struct 
 {
 	uint8_t port;
@@ -54,11 +50,9 @@ typedef struct
 	uint8_t size; //of the buffer
 } DIN_EVENT_QUEUE;
 
-#if defined(USE_DIN_SPI_DRIVER)
 #define SPI_SPEED_DIN         4000000
 //#define SPI_SPEED_DIN         2000000
 #define SPI_MODE_DIN          SPI_MODE0
-#endif
 
 // helper
 #define BIT_VALUE(a,n) ((a >> n)  & 0x01)		
@@ -85,9 +79,7 @@ class Din
 		int8_t getData(uint8_t port);				
 		uint8_t sizeOf();	
 		void plug(uint8_t setup);
-#if defined(USE_DIN_SPI_DRIVER) || defined(USE_DIN_BITBANG_DRIVER)
 		void plugSR(uint8_t setup);
-#endif
 		void encoder(uint8_t channel_a, uint8_t channel_b);
 
 		// default callback
@@ -113,13 +105,12 @@ class Din
     	volatile DIN_EVENT_QUEUE event_queue;	
 
 		// used for direct microcontroller digital input pins
-		uint8_t _button_pin[USE_DIN_MAX_PORTS] = {0};
+		//uint8_t _din_pin_map[16] = {0};
+		uint8_t * _din_pin_map = nullptr;
 
-#if defined(USE_DIN_SPI_DRIVER)
 		volatile SPIClass * _spi_device = nullptr;
 		void setSpi(SPIClass * spi_device = nullptr, uint8_t latch_pin = 2);
 		uint8_t _latch_pin;
-#endif
 };
 
 } }

--- a/module/dout/dout.hpp
+++ b/module/dout/dout.hpp
@@ -2,7 +2,7 @@
  *  @file       dout.hpp
  *  Project     Arduino Library API interface for uMODULAR projects
  *  @brief      Digital output driver module (595 shiftregister)
- *  @version    1.0.0
+ *  @version    1.1.0
  *  @author     Romulo Silva
  *  @date       30/10/22
  *  @license    MIT - (c) 2022 - Romulo Silva - contact@midilab.co
@@ -38,10 +38,6 @@ namespace uctrl { namespace module {
 //#define SPI_SPEED_DOUT         2000000
 #define SPI_MODE_DOUT          SPI_MODE0	
 
-#if !defined(USE_DOUT_MAX_PORTS)
-#define USE_DOUT_MAX_PORTS      8
-#endif
-
 // helper
 #define BIT_GET_VALUE(a,n) ((a >> n)  & 0x01)
 
@@ -61,18 +57,16 @@ class Dout
         void writeAll(uint8_t value, uint8_t interrupted = 0);		
         uint8_t sizeOf();	
         void plug(uint8_t setup);
-#if defined(USE_DOUT_SPI_DRIVER) || defined(USE_DOUT_BITBANG_DRIVER)
         void plugSR(uint8_t setup);
-#endif
         void setTimer(uint32_t time);
         bool blink();
 
-#if defined(USE_DOUT_SPI_DRIVER) || defined(USE_DOUT_BITBANG_DRIVER)
         uint8_t * _digital_output_state = nullptr;
         volatile uint8_t * _digital_output_buffer = nullptr;
-#endif
+
         // used for direct microcontroller digital output pins
-	uint8_t _dout_pin[USE_DOUT_MAX_PORTS] = {0};
+	//uint8_t _dout_pin_map[16] = {0};
+        uint8_t * _dout_pin_map = nullptr;
 
         uint8_t _remote_digital_output_port = 0; 
 
@@ -84,11 +78,9 @@ class Dout
 	bool _blink = false;
 	uint32_t _blink_timer = 0;
 
-#if defined(USE_DOUT_SPI_DRIVER)
 	volatile SPIClass * _spi_device = nullptr;
-	void setSpi(SPIClass * spi_device = nullptr, uint8_t chip_select = 2);
+	void setSpi(SPIClass * spi_device = nullptr, uint8_t latch_pin = 2);
         int8_t _latch_pin = -1;
-#endif
 
 };
 

--- a/module/midi/midi.cpp
+++ b/module/midi/midi.cpp
@@ -1,7 +1,3 @@
-#include "../../../../modules.h"
-
-#ifdef USE_MIDI
-
 #include "midi.hpp"
 
 namespace uctrl { namespace module {
@@ -467,4 +463,3 @@ void Midi::handleStop()
 } }
 
 uctrl::module::Midi midi_module;
-#endif

--- a/module/oled/oled.cpp
+++ b/module/oled/oled.cpp
@@ -26,10 +26,6 @@
  * DEALINGS IN THE SOFTWARE. 
  */
 
-#include "../../../../modules.h"
-
-#ifdef USE_OLED
-
 #include "oled.hpp"
 
 namespace uctrl { namespace module {
@@ -256,4 +252,3 @@ void Oled::inverseFont(bool inverse)
 } }
 
 uctrl::module::Oled oled_module;
-#endif

--- a/module/oled/oled.hpp
+++ b/module/oled/oled.hpp
@@ -29,6 +29,9 @@
 #ifndef __U_CTRL_OLED_HPP__
 #define __U_CTRL_OLED_HPP__
 
+// default library version
+#define USE_OLED_U8G2
+
 // U8x8 Oled driver library Support
 #ifdef USE_OLED_U8G2
 #include "U8g2/U8g2lib.h"

--- a/module/page/page.cpp
+++ b/module/page/page.cpp
@@ -26,10 +26,6 @@
  * DEALINGS IN THE SOFTWARE. 
  */
 
-#include "../../../../modules.h"
-
-#ifdef USE_PAGE
-
 #include "page.hpp"
 	
 namespace uctrl { namespace module {
@@ -49,14 +45,17 @@ Page::~Page()
 
 }
 
-void Page::init()
+void Page::init(uint8_t pages_size)
 {
 	// only init once!
 	if (_pages_size != 0) {
 		return;
 	}
 
-	_pages_size = USE_PAGE_MAX_PAGES;
+	// alloc once and forever policy!
+	_page_data = (PAGE_DATA*) malloc( sizeof(PAGE_DATA) * pages_size );
+
+	_pages_size = pages_size;
 }
 
 const char * Page::getPageName(int8_t page_id)
@@ -538,8 +537,9 @@ void Page::set(const char * page_name, void (*page_create_callback)(), void (*pa
 	_page_data[_page].name = page_name;
 
 #ifdef USE_PAGE_COMPONENT
-	// init selected component memory
-	for (uint8_t i=0; i < USE_PAGE_MAX_SUB_PAGES; i++) {
+	// init selected component memory, alloc once and forever policy!
+	_page_data[_page].sub_page_data = (SUB_PAGE_DATA*) malloc( sizeof(SUB_PAGE_DATA) * sub_page_size );
+	for (uint8_t i=0; i < sub_page_size; i++) {
 		_page_data[_page].sub_page_data[i].selected_component = nullptr;
 		_page_data[_page].sub_page_data[i].selector_line = 0;
 		_page_data[_page].sub_page_data[i].selector_grid = 0;
@@ -662,4 +662,3 @@ uint8_t Page::getPage()
 } }
 
 uctrl::module::Page page_module;
-#endif

--- a/module/page/page.cpp
+++ b/module/page/page.cpp
@@ -53,7 +53,9 @@ void Page::init(uint8_t pages_size)
 	}
 
 	// alloc once and forever policy!
-	_page_data = (PAGE_DATA*) malloc( sizeof(PAGE_DATA) * pages_size );
+	/* if (_page_data == nullptr) {
+		_page_data = (PAGE_DATA*) malloc( sizeof(PAGE_DATA) * pages_size );
+	} */
 
 	_pages_size = pages_size;
 }

--- a/module/page/page.cpp
+++ b/module/page/page.cpp
@@ -53,9 +53,25 @@ void Page::init(uint8_t pages_size)
 	}
 
 	// alloc once and forever policy!
-	/* if (_page_data == nullptr) {
+	if (_page_data == nullptr) {
 		_page_data = (PAGE_DATA*) malloc( sizeof(PAGE_DATA) * pages_size );
-	} */
+		// init page memory
+		for (uint8_t i=0; i < pages_size; i++) {
+			_page_data[i].create = nullptr;
+			_page_data[i].destroy = nullptr;
+			_page_data[i].refresh = nullptr;
+			_page_data[i].digital_input = nullptr;
+			_page_data[i].analog_input = nullptr;
+			_page_data[i].name = nullptr;
+			_page_data[i].callback_f1 = nullptr;
+			_page_data[i].callback_f2 = nullptr;
+			_page_data[i].f1 = nullptr;
+			_page_data[i].f2 = nullptr;
+			_page_data[i].f1_state = 0;
+			_page_data[i].f2_state = 0;
+			_page_data[i].sub_page_data = nullptr;
+		}
+	}
 
 	_pages_size = pages_size;
 }

--- a/module/page/page.hpp
+++ b/module/page/page.hpp
@@ -34,7 +34,6 @@
 // auto defines, change per dinamicly setup
 #define USE_PAGE_COMPONENT
 
-#define MAX_PAGES       6
 
 #ifdef USE_PAGE_COMPONENT	
 
@@ -290,8 +289,7 @@ class Page
         uint8_t _last_page;  
         bool _page_callback_create;
         bool _page_callback_destroy;
-        PAGE_DATA _page_data[MAX_PAGES];
-        //PAGE_DATA * _page_data = nullptr;
+        PAGE_DATA * _page_data = nullptr;
 
 #ifdef USE_PAGE_COMPONENT
         HOOK_CTRL_DATA _shift_hooker[MAX_SHIFT_HOOKERS_SIZE];

--- a/module/page/page.hpp
+++ b/module/page/page.hpp
@@ -34,6 +34,8 @@
 // auto defines, change per dinamicly setup
 #define USE_PAGE_COMPONENT
 
+#define MAX_PAGES       6
+
 #ifdef USE_PAGE_COMPONENT	
 
 #define COMPONENT_LINE  8
@@ -221,7 +223,6 @@ typedef struct
         uint8_t f1_state = 0;
         uint8_t f2_state = 0;
         // each subpage needs a reference pointer to wich is the selected component of the first one to be selected
-        //SUB_PAGE_DATA sub_page_data[USE_PAGE_MAX_SUB_PAGES];
         SUB_PAGE_DATA * sub_page_data = nullptr;
 #endif
 } PAGE_DATA;
@@ -289,8 +290,8 @@ class Page
         uint8_t _last_page;  
         bool _page_callback_create;
         bool _page_callback_destroy;
-        //PAGE_DATA _page_data[USE_PAGE_MAX_PAGES];
-        PAGE_DATA * _page_data = nullptr;
+        PAGE_DATA _page_data[MAX_PAGES];
+        //PAGE_DATA * _page_data = nullptr;
 
 #ifdef USE_PAGE_COMPONENT
         HOOK_CTRL_DATA _shift_hooker[MAX_SHIFT_HOOKERS_SIZE];

--- a/module/page/page.hpp
+++ b/module/page/page.hpp
@@ -31,9 +31,8 @@
 
 #include <Arduino.h>
 
-#ifndef USE_PAGE_MAX_PAGES
-#define USE_PAGE_MAX_PAGES      6
-#endif
+// auto defines, change per dinamicly setup
+#define USE_PAGE_COMPONENT
 
 #ifdef USE_PAGE_COMPONENT	
 
@@ -222,7 +221,8 @@ typedef struct
         uint8_t f1_state = 0;
         uint8_t f2_state = 0;
         // each subpage needs a reference pointer to wich is the selected component of the first one to be selected
-        SUB_PAGE_DATA sub_page_data[USE_PAGE_MAX_SUB_PAGES];
+        //SUB_PAGE_DATA sub_page_data[USE_PAGE_MAX_SUB_PAGES];
+        SUB_PAGE_DATA * sub_page_data = nullptr;
 #endif
 } PAGE_DATA;
 
@@ -232,7 +232,7 @@ class Page
         Page();
         ~Page(); 
   
-        void init();
+        void init(uint8_t pages_size);
         void setPage(int8_t page);	
         void setSubPage(int8_t sub_page);
         //void isPageSet(uint8_t page_number);
@@ -289,7 +289,8 @@ class Page
         uint8_t _last_page;  
         bool _page_callback_create;
         bool _page_callback_destroy;
-        PAGE_DATA _page_data[USE_PAGE_MAX_PAGES];
+        //PAGE_DATA _page_data[USE_PAGE_MAX_PAGES];
+        PAGE_DATA * _page_data = nullptr;
 
 #ifdef USE_PAGE_COMPONENT
         HOOK_CTRL_DATA _shift_hooker[MAX_SHIFT_HOOKERS_SIZE];

--- a/module/ram/ram.cpp
+++ b/module/ram/ram.cpp
@@ -1,5 +1,3 @@
-#include "../../../../modules.h"
-
 #ifdef USE_EXT_RAM
 
 #include "ram.hpp"

--- a/module/sdcard/sdcard.cpp
+++ b/module/sdcard/sdcard.cpp
@@ -1,5 +1,3 @@
-#include "../../../../modules.h"
-
 #ifdef USE_SDCARD
 /*
  we need 2 ways of handling files

--- a/module/storage/storage.cpp
+++ b/module/storage/storage.cpp
@@ -26,10 +26,6 @@
  * DEALINGS IN THE SOFTWARE. 
  */
 
-#include "../../../../modules.h"
-
-#ifdef USE_STORAGE
-
 #include "storage.hpp"
 
 namespace uctrl { namespace module {
@@ -105,4 +101,3 @@ bool Storage::load(void *data, size_t n, const char * path)
 } }
 
 uctrl::module::Storage storage_module;
-#endif

--- a/module/touch/FastTouch.cpp
+++ b/module/touch/FastTouch.cpp
@@ -1,7 +1,3 @@
-#include "../../../../modules.h"
-
-#ifdef USE_CAP_TOUCH
-
 //
 //  FastTouch.cpp
 //  
@@ -803,6 +799,3 @@ int fastTouchMax()
 {
     return 60;
 }
-
-
-#endif

--- a/module/touch/touch.cpp
+++ b/module/touch/touch.cpp
@@ -25,11 +25,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE. 
  */
-
-#include "../../../../modules.h"
-
-#ifdef USE_CAP_TOUCH
-
 #include "touch.hpp"
 
 namespace uctrl { namespace module {
@@ -179,4 +174,3 @@ void CapTouch::read()
 } }
 
 uctrl::module::CapTouch cap_touch_module;
-#endif

--- a/uCtrl.cpp
+++ b/uCtrl.cpp
@@ -255,15 +255,15 @@ bool uCtrlClass::initDin(SPIClass * spi_device, uint8_t latch_pin)
 	}
 }
 
-bool uCtrlClass::initAin(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
+bool uCtrlClass::initAin(int8_t pin1, int8_t pin2, int8_t pin3, int8_t pin4)
 {
 	if ( ain == nullptr ) {
 		ain = &ain_module;
 	}
 	
 	if ( ain != nullptr ) {
-		// pin1 passaed as argument means mux request to register
-		if (pin1 != 0) {
+		// pin1 as argument means mux request to register
+		if (pin1 >= 0) {
 			ain->setMuxPins(pin1, pin2, pin3, pin4);
 		}
 		return true;
@@ -318,7 +318,7 @@ void uCtrlClass::processAin()
 	}
 }
 
-bool uCtrlClass::initCapTouch(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
+bool uCtrlClass::initCapTouch(int8_t pin1, int8_t pin2, int8_t pin3, int8_t pin4)
 {
 	if ( touch == nullptr ) {
 		touch = &cap_touch_module;

--- a/uCtrl.cpp
+++ b/uCtrl.cpp
@@ -101,7 +101,7 @@ bool uCtrlClass::initRam(SPIClass * device)
 }
 #endif // defined(USE_EXT_RAM)
 
-#if defined(USE_STORAGE)
+//#if defined(USE_STORAGE)
 bool uCtrlClass::initStorage(SPIClass * spi_device)
 {
 	if ( storage == nullptr ) {
@@ -117,7 +117,7 @@ bool uCtrlClass::initStorage(SPIClass * spi_device)
 	}	
 	return false;
 }
-#endif // defined(USE_STORAGE)
+//#endif // defined(USE_STORAGE)
 
 #if defined(USE_SDCARD)
 bool uCtrlClass::initSdCard(SPIClass * spi_device)
@@ -151,23 +151,19 @@ bool uCtrlClass::initDevice(uint8_t device_number, uint16_t event_buffer_size, u
 }
 #endif // defined(USE_DEVICE)
 
-#if defined(USE_PAGE)
-bool uCtrlClass::initPage()
+bool uCtrlClass::initPage(uint8_t pages_size)
 {
 	if ( page == nullptr ) {
 		page = &page_module;
 	}
 	
 	if ( page != nullptr ) {
-		page->init();
+		page->init(pages_size);
 		return true;
 	} else {
 		return false;
 	}
 }
-#endif // defined(USE_PAGE)
-
-#if defined(USE_OLED)
 
 #if defined(USE_OLED_U8G2)
 bool uCtrlClass::initOled(U8G2 * display)
@@ -206,9 +202,6 @@ void uCtrlClass::processDisplay()
 #endif // defined(USE_DEVICE)
 #endif // defined(USE_EXT_RAM)
 
-#endif // #if defined(USE_OLED)
-
-#if defined(USE_MIDI)
 bool uCtrlClass::initMidi()
 {
 	if ( midi == nullptr ) {
@@ -229,29 +222,23 @@ void uCtrlClass::processMidi()
 		midi->read(port);
 	}
 }
-#endif // defined(USE_MIDI)
 
-#if defined(USE_DOUT)
 bool uCtrlClass::initDout(SPIClass * spi_device, uint8_t latch_pin)
 {
 	if ( dout == nullptr ) {
 		dout = &dout_module;
 	}
 	
-	if ( dout != nullptr ) {
-#if defined(USE_DOUT_SPI_DRIVER)		
+	if ( dout != nullptr ) {	
 		if (spi_device != nullptr) {
 			dout->setSpi(spi_device, latch_pin);
 		}
-#endif // defined(USE_DOUT_SPI_DRIVER)
 		return true;
 	} else {
 		return false;
 	}
 }
-#endif // defined(USE_DOUT)
 
-#if defined(USE_DIN)
 bool uCtrlClass::initDin(SPIClass * spi_device, uint8_t latch_pin)
 {
 	if ( din == nullptr ) {
@@ -259,19 +246,15 @@ bool uCtrlClass::initDin(SPIClass * spi_device, uint8_t latch_pin)
 	}
 	
 	if ( din != nullptr ) {
-#if defined(USE_DIN_SPI_DRIVER)		
 		if (spi_device != nullptr) {
 			din->setSpi(spi_device, latch_pin);
 		}
-#endif // defined(USE_DIN_SPI_DRIVER)
 		return true;
 	} else {
 		return false;
 	}
 }
-#endif // defined(USE_DIN)
 
-#if defined(USE_AIN)
 bool uCtrlClass::initAin(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
 {
 	if ( ain == nullptr ) {
@@ -279,9 +262,10 @@ bool uCtrlClass::initAin(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
 	}
 	
 	if ( ain != nullptr ) {
-#if defined(USE_AIN_4051_DRIVER) || defined(USE_AIN_4067_DRIVER)
-		ain->setMuxPins(pin1, pin2, pin3, pin4);
-#endif
+		// pin1 passaed as argument means mux request to register
+		if (pin1 != 0) {
+			ain->setMuxPins(pin1, pin2, pin3, pin4);
+		}
 		return true;
 	} else {
 		return false;
@@ -333,9 +317,7 @@ void uCtrlClass::processAin()
 		
 	}
 }
-#endif // defined(USE_AIN)
 
-#if defined(USE_CAP_TOUCH)
 bool uCtrlClass::initCapTouch(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4)
 {
 	if ( touch == nullptr ) {
@@ -349,7 +331,6 @@ bool uCtrlClass::initCapTouch(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t 
 		return false;
 	}
 }
-#endif // defined(USE_CAP_TOUCH)
 
 void uCtrlClass::init()
 {
@@ -361,32 +342,32 @@ void uCtrlClass::init()
 	// load factory defaults
 #endif // defined(USE_SDCARD)
 
-#if defined(USE_AIN)
-	ain->init();
-	_ain_event_queue.head = 0;
-	_ain_event_queue.tail = 0;
-	_ain_event_queue.size = 8;		
-#endif // defined(USE_AIN)
-
-#if defined(USE_CAP_TOUCH)
-	touch->init();
-#endif // defined(USE_CAP_TOUCH)
-
-#if defined(USE_DIN)
-	din->init();
-#endif // defined(USE_DIN)
-	
-#if defined(USE_DOUT)
-	dout->init();
-#endif // defined(USE_DOUT)
-			
-#if defined(USE_PAGE)
-	// default page and subpge
-	if (page->getPageSize() > 0) {
-		page->setPage(0);
-		page->setSubPage(0);
+	if (ain != nullptr) {
+		ain->init();
+		_ain_event_queue.head = 0;
+		_ain_event_queue.tail = 0;
+		_ain_event_queue.size = 8;
 	}
-#endif // defined(USE_PAGE)
+
+	if (touch != nullptr) {
+		touch->init();
+	}
+
+	if (din != nullptr) {
+		din->init();
+	}
+	
+	if (dout != nullptr) {
+		dout->init();
+	}
+			
+	if (page != nullptr) {
+		// default page and subpge
+		if (page->getPageSize() > 0) {
+			page->setPage(0);
+			page->setSubPage(0);
+		}
+	}
 	
 	// ...
 	enableTimer();
@@ -401,141 +382,140 @@ void uCtrlClass::run()
 
 	// timmer dependent UI visual effects
 	uint32_t time = millis();
-#if defined(USE_DOUT)
-	uCtrl.dout->setTimer(time);
-#endif // defined(USE_DOUT)
-#if defined(USE_OLED)
-	uCtrl.oled->setTimer(time);
-#endif // defined(USE_OLED)
-
-#if defined(USE_OLED)
+	if (dout != nullptr) {
+		uCtrl.dout->setTimer(time);
+	}
+	if ( oled != nullptr ) {
+		uCtrl.oled->setTimer(time);
 #if defined(USE_OLED_U8G2)
-	oled->clearDisplay();
+		uCtrl.oled->clearDisplay();
 #endif // defined(USE_OLED_U8G2)
-#endif // defined(USE_OLED)
+	}
 
-#if defined(USE_DIN) 
 	// din
-	// read while empty
-	while ( din->event_queue.head != din->event_queue.tail )
-	{
-		port = din->event_queue.event[din->event_queue.head].port;
-		value = din->event_queue.event[din->event_queue.head].value; 
-		head = (din->event_queue.head+1)%(din->event_queue.size);
-		ATOMIC(
-			din->event_queue.head = head
-		)
+	if (din != nullptr) {
+		// read while empty
+		while ( din->event_queue.head != din->event_queue.tail )
+		{
+			port = din->event_queue.event[din->event_queue.head].port;
+			value = din->event_queue.event[din->event_queue.head].value; 
+			head = (din->event_queue.head+1)%(din->event_queue.size);
+			ATOMIC(
+				din->event_queue.head = head
+			)
 
-#if defined(USE_DEVICE)
-	   if ( device->handleDigitalEvent(port, value, 0) == true ) {
-			continue;
-	   }
-#endif // defined(USE_DEVICE)
+	#if defined(USE_DEVICE)
+		if ( device->handleDigitalEvent(port, value, 0) == true ) {
+				continue;
+		}
+	#endif // defined(USE_DEVICE)
 
-#if defined(USE_PAGE)
-#if defined(USE_AIN) && defined(USE_PAGE_COMPONENT)
-		// before each processEvent we need to: check if pot_ctrl is needed
-		if(page->_use_nav_pot) {
-			// if it is, check if it is inc or dec commands... 
-			if (port == page->_nav_ctrl_port.incrementer || 
-				port == page->_nav_ctrl_port.decrementer ||
-				port == page->_nav_ctrl_port.incrementer_secondary || 
-				port == page->_nav_ctrl_port.decrementer_secondary ||
-				port == page->_nav_ctrl_port.up || 
-				port == page->_nav_ctrl_port.down ||
-				port == page->_nav_ctrl_port.left || 
-				port == page->_nav_ctrl_port.right) {
-				// if it is. lock ain pot control to avoid mess with inc/dec changes
-				ain->lockControl(page->_nav_ctrl_port.pot);
-				// we also need to remove from our event queue any data from nav pot
-				discard_ain_data = true;
+		if (page != nullptr) {
+			if (ain != nullptr) {
+	#if defined(USE_PAGE_COMPONENT)
+				// before each processEvent we need to: check if pot_ctrl is needed
+				if(page->_use_nav_pot) {
+					// if it is, check if it is inc or dec commands... 
+					if (port == page->_nav_ctrl_port.incrementer || 
+						port == page->_nav_ctrl_port.decrementer ||
+						port == page->_nav_ctrl_port.incrementer_secondary || 
+						port == page->_nav_ctrl_port.decrementer_secondary ||
+						port == page->_nav_ctrl_port.up || 
+						port == page->_nav_ctrl_port.down ||
+						port == page->_nav_ctrl_port.left || 
+						port == page->_nav_ctrl_port.right) {
+						// if it is. lock ain pot control to avoid mess with inc/dec changes
+						ain->lockControl(page->_nav_ctrl_port.pot);
+						// we also need to remove from our event queue any data from nav pot
+						discard_ain_data = true;
+					}
+				}
+	#endif // defined(USE_PAGE_COMPONENT)
 			}
+			page->processEvent(port, value, uctrl::module::DIGITAL_EVENT);
 		}
-#endif // defined(USE_AIN) && defined(USE_PAGE_COMPONENT)
-		page->processEvent(port, value, uctrl::module::DIGITAL_EVENT);
-#endif // defined(USE_PAGE)
 
-	   if ( din->callback != nullptr ) {
-			din->callback(port, value);
-	   }
+		if ( din->callback != nullptr ) {
+				din->callback(port, value);
+		}
+		}
+		// set port_ref in case other digital modules were initialized
+		port_ref = din->sizeOf();
 	}
-	// set port_ref in case other digital modules were initialized
-	port_ref = din->sizeOf();
-#endif // defined(USE_DIN) 
 
-#if defined(USE_CAP_TOUCH)
-	// touch
-	// read while empty
-	while ( touch->event_queue.head != touch->event_queue.tail )
-	{
-		// use port_ref in case din were initialized
-		port = touch->event_queue.event[touch->event_queue.head].port+port_ref;
-		value = touch->event_queue.event[touch->event_queue.head].value; 
-		head = (touch->event_queue.head+1)%(touch->event_queue.size);
-		ATOMIC(
-			touch->event_queue.head = head
-		)
+	if (touch != nullptr) {
+		// touch
+		// read while empty
+		while ( touch->event_queue.head != touch->event_queue.tail )
+		{
+			// use port_ref in case din were initialized
+			port = touch->event_queue.event[touch->event_queue.head].port+port_ref;
+			value = touch->event_queue.event[touch->event_queue.head].value; 
+			head = (touch->event_queue.head+1)%(touch->event_queue.size);
+			ATOMIC(
+				touch->event_queue.head = head
+			)
 
-#if defined(USE_DEVICE)
-	   if ( device->handleDigitalEvent(port, value, 0) == true ) {
-			continue;
-	   }
-#endif // defined(USE_DEVICE)                
-
-#if defined(USE_PAGE)
-#if defined(USE_AIN) 
-		// before each processEvent we need to: check if pot_ctrl is needed
-		if(page->_use_nav_pot) {
-			// if it is, check if it is inc or dec commands... 
-			if (port == page->_nav_ctrl_port.incrementer || 
-				port == page->_nav_ctrl_port.decrementer ||
-				port == page->_nav_ctrl_port.incrementer_secondary || 
-				port == page->_nav_ctrl_port.decrementer_secondary ||
-				port == page->_nav_ctrl_port.up || 
-				port == page->_nav_ctrl_port.down ||
-				port == page->_nav_ctrl_port.left || 
-				port == page->_nav_ctrl_port.right) {
-				// if it is. lock ain pot control to avoid mess with inc/dec changes
-				ain->lockControl(page->_nav_ctrl_port.pot);
-				// we also need to remove from our event queue any data from nav pot
-				discard_ain_data = true;
-			}
+	#if defined(USE_DEVICE)
+		if ( device->handleDigitalEvent(port, value, 0) == true ) {
+				continue;
 		}
-#endif // defined(USE_AIN)
-		page->processEvent(port, (uint16_t)value, uctrl::module::DIGITAL_EVENT);
-#endif // defined(USE_PAGE)
+	#endif // defined(USE_DEVICE)                
 
-		if ( touch->callback != nullptr ) {
-			touch->callback(port, value);
-		}
-	}
-#endif // defined(USE_CAP_TOUCH)
-
-#if defined(USE_AIN) 
-   // ain:
-   // read while empty
-   while ( _ain_event_queue.head != _ain_event_queue.tail )
-   {
-		port = _ain_event_queue.event[_ain_event_queue.head].port;
-		value = _ain_event_queue.event[_ain_event_queue.head].value;  
-		head = (_ain_event_queue.head+1) >= _ain_event_queue.size ? 0 : (_ain_event_queue.head+1);
-		ATOMIC(                      
-			_ain_event_queue.head = head
-		)
-
-#if defined(USE_PAGE_COMPONENT)
-		if (discard_ain_data) {
-			if (port == page->_nav_ctrl_port.pot) {
-				if (ain->isLocked(page->_nav_ctrl_port.pot) == false) {
-					discard_ain_data = false;
-				} else {
-					continue;
+		if (page != nullptr) {
+			if (ain != nullptr) {
+				// before each processEvent we need to: check if pot_ctrl is needed
+				if(page->_use_nav_pot) {
+					// if it is, check if it is inc or dec commands... 
+					if (port == page->_nav_ctrl_port.incrementer || 
+						port == page->_nav_ctrl_port.decrementer ||
+						port == page->_nav_ctrl_port.incrementer_secondary || 
+						port == page->_nav_ctrl_port.decrementer_secondary ||
+						port == page->_nav_ctrl_port.up || 
+						port == page->_nav_ctrl_port.down ||
+						port == page->_nav_ctrl_port.left || 
+						port == page->_nav_ctrl_port.right) {
+						// if it is. lock ain pot control to avoid mess with inc/dec changes
+						ain->lockControl(page->_nav_ctrl_port.pot);
+						// we also need to remove from our event queue any data from nav pot
+						discard_ain_data = true;
+					}
 				}
 			}
+			page->processEvent(port, (uint16_t)value, uctrl::module::DIGITAL_EVENT);
 		}
-#endif // defined(USE_PAGE_COMPONENT)
 
-#if defined(USE_DEVICE)
+			if ( touch->callback != nullptr ) {
+				touch->callback(port, value);
+			}
+		}
+	}
+
+	if (ain != nullptr) {
+		// ain:
+		// read while empty
+		while ( _ain_event_queue.head != _ain_event_queue.tail )
+		{
+			port = _ain_event_queue.event[_ain_event_queue.head].port;
+			value = _ain_event_queue.event[_ain_event_queue.head].value;  
+			head = (_ain_event_queue.head+1) >= _ain_event_queue.size ? 0 : (_ain_event_queue.head+1);
+			ATOMIC(                      
+				_ain_event_queue.head = head
+			)
+
+	#if defined(USE_PAGE_COMPONENT)
+			if (discard_ain_data) {
+				if (port == page->_nav_ctrl_port.pot) {
+					if (ain->isLocked(page->_nav_ctrl_port.pot) == false) {
+						discard_ain_data = false;
+					} else {
+						continue;
+					}
+				}
+			}
+	#endif // defined(USE_PAGE_COMPONENT)
+
+	#if defined(USE_DEVICE)
 			// device process are done inside interrupt to keep smooth for realtime controllers events
 			// EDIT MODE HANDLER
 			if ( device->getCtrlMode() == 2 ) {
@@ -545,49 +525,47 @@ void uCtrlClass::run()
 			if ( device->handleAnalogEvent(port, value, 0) == true ) {
 				continue;
 			}
-#endif // defined(USE_DEVICE)
+	#endif // defined(USE_DEVICE)
 
-#if defined(USE_PAGE)
-		page->processEvent(port, value, uctrl::module::ANALOG_EVENT);
-#endif // defined(USE_PAGE)
+			if (page != nullptr) {
+				page->processEvent(port, value, uctrl::module::ANALOG_EVENT);
+			}
 
-		if ( ain->callback != nullptr ) {
-			ain->callback(port, value);
+			if ( ain->callback != nullptr ) {
+				ain->callback(port, value);
+			}
 		}
-	}
-#endif // defined(USE_AIN)    
-     
-#if defined(USE_PAGE)                
+	} 
+              
 	if ( page != nullptr ) {
 #if defined(USE_PAGE_COMPONENT)
 		page->clearComponentMap();
 #endif // defined(USE_PAGE_COMPONENT)
 		page->processView();
 	}
-#endif // defined(USE_PAGE)   
 
-#if defined(USE_OLED)
+	if ( oled != nullptr ) {
 #if defined(USE_EXT_RAM)
 #if defined(USE_DEVICE)
-    processDisplay();
+    	processDisplay();
 #endif // defined(USE_DEVICE)
 #endif // defined(USE_EXT_RAM)
 #if defined(USE_OLED_U8G2)
-	oled->refreshDisplay();
+		oled->refreshDisplay();
 #endif // defined(USE_OLED_U8G2)
-#endif // defined(USE_OLED)
+	}
 
-#if defined(USE_DOUT)
-	uCtrl.dout->flushBuffer();
-#endif // defined(USE_DOUT)        	
+	if (dout != nullptr) {
+		uCtrl.dout->flushBuffer();
+	}
 }
 
 uint8_t uCtrlClass::getAnalogPorts()
 {
 
-#if defined(USE_AIN)
-	return ain->sizeOf();
-#endif // defined(USE_AIN)
+	if (ain != nullptr) {
+		return ain->sizeOf();
+	}
 
 	return 0;
 }
@@ -595,9 +573,9 @@ uint8_t uCtrlClass::getAnalogPorts()
 uint8_t uCtrlClass::getDigitalPorts()
 {
 
-#if defined(USE_DIN)
-	return din->sizeOf();
-#endif // defined(USE_DIN)
+	if (din != nullptr) {
+		return din->sizeOf();
+	}
 
 	return 0;
 }
@@ -605,11 +583,7 @@ uint8_t uCtrlClass::getDigitalPorts()
 uint8_t uCtrlClass::getOutputPorts()
 {
 
-#if defined(USE_MIDI)
 	return midi->sizeOf();
-#endif // defined(USE_MIDI)
-
-	return 0;
 	
 /*
 #if defined(UMODULAR_DMX)	
@@ -671,42 +645,42 @@ void uCtrlHandler()
 		}
 	}
 
-#if defined(USE_DIN)
-	// ~2ms call
-	if (++_timerCounterDin == 8) {
-		_timerCounterDin = 0;
-		uCtrl.din->read(1);
-		return;
+	if (uCtrl.din != nullptr) {
+		// ~2ms call
+		if (++_timerCounterDin == 8) {
+			_timerCounterDin = 0;
+			uCtrl.din->read(1);
+			return;
+		}
 	}
-#endif // defined(USE_DIN)
 
-#if defined(USE_CAP_TOUCH)	
-	// ~3ms call
-	if (++_timerCapTouch == 12) 
-	{
-		_timerCapTouch = 0;
-		uCtrl.touch->read();
-		return;
+	if (uCtrl.touch != nullptr) {
+		// ~3ms call
+		if (++_timerCapTouch == 12) 
+		{
+			_timerCapTouch = 0;
+			uCtrl.touch->read();
+			return;
+		}
 	}
-#endif // defined(USE_CAP_TOUCH)
 
-#if defined(USE_AIN)
-	// ~10ms call
-	if (++_timerCounterAin == 40) 
-	{
-		_timerCounterAin = 0;
-		uCtrl.processAin();
-		return;
+	if (uCtrl.ain != nullptr) {
+		// ~10ms call
+		if (++_timerCounterAin == 40) 
+		{
+			_timerCounterAin = 0;
+			uCtrl.processAin();
+			return;
+		}
 	}
-#endif // defined(USE_AIN)
 
-#if defined(USE_DOUT)
-	// ~30ms call
-	if (++_timerCounterDout == 120) {
-		_timerCounterDout = 0;
-		uCtrl.dout->flush(1);
-		return;
+	if (uCtrl.dout != nullptr) {
+		// ~30ms call
+		if (++_timerCounterDout == 120) {
+			_timerCounterDout = 0;
+			uCtrl.dout->flush(1);
+			return;
+		}
 	}
-#endif // defined(USE_DOUT)
 
 }

--- a/uCtrl.h
+++ b/uCtrl.h
@@ -32,49 +32,31 @@
 #include <Arduino.h> 
 #include <SPI.h>
 
-#include "../../modules.h"
-
 // modules classes includes
-#if defined(USE_OLED)
 #include "module/oled/oled.hpp"
-#endif // defined(USE_OLED)
 
-#if defined(USE_MIDI)
 #include "module/midi/midi.hpp"
-#endif // defined(USE_MIDI)
 
 // dout 595 or single output for arduino only
-#if defined(USE_DOUT)
 #include "module/dout/dout.hpp"
-#endif // defined(USE_DOUT)
 
-#if defined(USE_DIN)
 #include "module/din/din.hpp"
-#endif // defined(USE_DIN)
 
-#if defined(USE_AIN)
 #include "module/ain/ain.hpp"
-#endif // defined(USE_AIN)
 
-#if defined(USE_CAP_TOUCH)
 #include "module/touch/touch.hpp"
-#endif // defined(USE_CAP_TOUCH)
 
 #if defined(USE_EXT_RAM)
 #include "module/ram/ram.hpp"
 #endif // defined(USE_EXT_RAM)
 
-#if defined(USE_STORAGE)
 #include "module/storage/storage.hpp"
-#endif // defined(USE_STORAGE)
 
 #if defined(USE_SDCARD)
 #include "module/sdcard/sdcard.hpp"
 #endif // defined(USE_SDCARD)
 
-#if defined(USE_PAGE)
 #include "module/page/page.hpp"
-#endif // defined(USE_PAGE)
 
 #if defined(USE_DEVICE)
 #include "module/device/device.hpp"
@@ -121,12 +103,9 @@ class uCtrlClass
 	uctrl::module::Ram * ram = nullptr;		
 #endif // defined(USE_EXT_RAM)
 
-#if defined(USE_STORAGE)
 	bool initStorage(SPIClass * spi_device = nullptr);
-	uctrl::module::Storage * storage = nullptr;		
-#endif // defined(USE_STORAGE)
+	uctrl::module::Storage * storage = nullptr;	
 
-#if defined(USE_OLED)	
 	// oled module
 #if defined(USE_OLED_U8G2)
 	bool initOled(U8G2 * display);
@@ -140,40 +119,29 @@ class uCtrlClass
 #endif // defined(USE_DEVICE)
 #endif // defined(USE_EXT_RAM)
 	uctrl::module::Oled * oled = nullptr;
-#endif	// defined(USE_OLED)
 
-#if defined(USE_MIDI)
 	// midi module
 	bool initMidi();
 	void processMidi();
 	uctrl::module::Midi * midi = nullptr;
-#endif // defined(USE_MIDI)
 	
-#if defined(USE_DOUT)	
 	// dout module
 	bool initDout(SPIClass * spi_device = nullptr, uint8_t latch_pin = 2);
 	uctrl::module::Dout * dout = nullptr;
-#endif // defined(USE_DOUT)
 	
-#if defined(USE_DIN)
 	// din module
 	bool initDin(SPIClass * spi_device = nullptr, uint8_t latch_pin = 2);
 	uctrl::module::Din * din = nullptr;
-#endif // defined(USE_DIN)
 	
-#if defined(USE_AIN)
 	// ain module
 	bool initAin(uint8_t pin1 = 0, uint8_t pin2 = 0, uint8_t pin3 = 0, uint8_t pin4 = 0);
 	void processAin();
 	uctrl::module::Ain * ain = nullptr;
-    volatile EVENT_QUEUE _ain_event_queue;	
-#endif // defined(USE_AIN)
+    volatile EVENT_QUEUE _ain_event_queue;
 	
-#if defined(USE_CAP_TOUCH)
 	// capacitive touch module
 	bool initCapTouch(uint8_t pin1 = 0, uint8_t pin2 = 0, uint8_t pin3 = 0, uint8_t pin4 = 0);
 	uctrl::module::CapTouch * touch = nullptr;
-#endif // defined(USE_CAP_TOUCH)
 	
 #if defined(USE_SDCARD)
 	// sdcard module
@@ -181,12 +149,10 @@ class uCtrlClass
 	uctrl::module::SdCard * sdcard;
 #endif // defined(USE_SDCARD)
 	
-#if defined(USE_PAGE)
 	// page module
-	bool initPage();
+	bool initPage(uint8_t pages_size);
 	void processPage();
 	uctrl::module::Page * page = nullptr;
-#endif // defined(USE_PAGE)
 	
 #if defined(USE_DEVICE)	
 	// device module

--- a/uCtrl.h
+++ b/uCtrl.h
@@ -134,13 +134,13 @@ class uCtrlClass
 	uctrl::module::Din * din = nullptr;
 	
 	// ain module
-	bool initAin(uint8_t pin1 = 0, uint8_t pin2 = 0, uint8_t pin3 = 0, uint8_t pin4 = 0);
+	bool initAin(int8_t pin1 = -1, int8_t pin2 = -1, int8_t pin3 = -1, int8_t pin4 = -1);
 	void processAin();
 	uctrl::module::Ain * ain = nullptr;
     volatile EVENT_QUEUE _ain_event_queue;
 	
 	// capacitive touch module
-	bool initCapTouch(uint8_t pin1 = 0, uint8_t pin2 = 0, uint8_t pin3 = 0, uint8_t pin4 = 0);
+	bool initCapTouch(int8_t pin1 = -1, int8_t pin2 = -1, int8_t pin3 = -1, int8_t pin4 = -1);
 	uctrl::module::CapTouch * touch = nullptr;
 	
 #if defined(USE_SDCARD)


### PR DESCRIPTION
This release cleans some of the dependencies on modules.h, now everything is done in runtime based on API config calls.

This change makes the library more easy to use and integrate into different platforms like platformIO and Arduino.

BREAK CHANGE!
Old projects should migrate to new schema. You wont need modules.h anymore, most of the API calls were keep the same, but setup now runs at runtime instead of compile.